### PR TITLE
This will allow the npm scripts to run on Windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,7 @@ branches:
     only:
         - master
 language: node_js
+node_js:
+  - "node"
 script:
-    - npm run build
+  - npm run build

--- a/package.json
+++ b/package.json
@@ -23,13 +23,13 @@
     "url": "https://github.com/devyumao/angular2-busy"
   },
   "scripts": {
-    "build": "NODE_ENV=busy webpack --progress",
-    "watch": "NODE_ENV=busy webpack --inline --progress --profile --colors --watch --display-error-details --display-cached --content-base build",
+    "build": "cross-env NODE_ENV=busy webpack --progress",
+    "watch": "cross-env NODE_ENV=busy webpack --inline --progress --profile --colors --watch --display-error-details --display-cached --content-base build",
     "build:busy": "npm run build",
     "watch:busy": "npm run watch",
-    "build:demo": "NODE_ENV=demo webpack --progress",
-    "watch:demo": "NODE_ENV=demo webpack-dev-server --inline --progress --profile --colors --watch --display-error-details --display-cached --content-base demo/asset",
-    "test": "NODE_ENV=test webpack --inline --progress --colors --watch --content-base test"
+    "build:demo": "cross-env NODE_ENV=demo webpack --progress",
+    "watch:demo": "cross-env NODE_ENV=demo webpack-dev-server --inline --progress --profile --colors --watch --display-error-details --display-cached --content-base demo/asset",
+    "test": "cross-env NODE_ENV=test webpack --inline --progress --colors --watch --content-base test"
   },
   "dependencies": {
     "ts-metadata-helper": "0.0.3",
@@ -50,6 +50,7 @@
     "compression-webpack-plugin": "^0.3.1",
     "copy-webpack-plugin": "^3.0.1",
     "core-js": "^2.4.1",
+    "cross-env": "^3.1.2",
     "extract-text-webpack-plugin": "^1.0.1",
     "html-webpack-plugin": "^2.19.0",
     "install": "^0.8.1",


### PR DESCRIPTION
Trying to run the build:busy and build:demo scripts on Windows would fail. Adding the cross-env package as a devDepency and updating the scripts will allow building on all platforms.

I also updated the node version used by Travis as it was using version 0.10. Most angular 2 examples requires a minimum of node 4.x.x and npm 3.x.x.. Eg. the github angular 2 quickstart as documented at https://angular.io/docs/ts/latest/quickstart.html
